### PR TITLE
feat: add CSV/JSON data import

### DIFF
--- a/Roam.xcodeproj/project.pbxproj
+++ b/Roam.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		2F58DFD0E9141CE4608A77D9 /* YearOverYearView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E0F64E8EA98CCC7B86A87F1 /* YearOverYearView.swift */; };
 		45FEA24C9A0F3D0977A94A82 /* InsightsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 161355E300E961AC6947F70E /* InsightsView.swift */; };
 		4AB82FA66BB533444D897559 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9D868ACDE0717F8AD4523DD /* OnboardingView.swift */; };
+		5481C098BC3D13AC24D7EBC3 /* DataImportServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E7743148F503481970D52BA /* DataImportServiceTests.swift */; };
 		548F7A9523DFD7FB13D6995E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1D3A9470466B0ACE9F8CE3 /* ContentView.swift */; };
 		57C6A2A2F4154CFF796A4F06 /* RoamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB87FA04018026E1981F420 /* RoamTests.swift */; };
 		5992C8E61D86C6986D989164 /* CityDisplayFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29A77B7801B9C1F699E56789 /* CityDisplayFormatterTests.swift */; };
@@ -37,6 +38,7 @@
 		7B4E9326C95605459F6895A1 /* ColorPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213B5349FB94E1A2C401CC74 /* ColorPalette.swift */; };
 		879C5CD335AA4ACA9C45DD85 /* LocationCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8ABCCB1F8C28A401A4831A /* LocationCaptureService.swift */; };
 		89BD48C7D72221F9B4F0A7D4 /* RoamApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9AF33526A2A15F22EA0FD5C /* RoamApp.swift */; };
+		8FCAB67D06A78874B66FF314 /* DataImportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 869AEC55168DE37DD3EC5624 /* DataImportService.swift */; };
 		90FDDDF4C2346380FBFD0837 /* DayCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D7FF89B107B4B4154B20D9C /* DayCell.swift */; };
 		9208A7F0FA8A35FC62430A99 /* AnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 778687BCAF748015DFE68915 /* AnalyticsService.swift */; };
 		9CE4FD5AD7637F16624234D1 /* CaptureResultSaverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F6EF6C7B88382F6E50BD98 /* CaptureResultSaverTests.swift */; };
@@ -52,6 +54,7 @@
 		CBA165938F38E9E4E20CFA92 /* BackfillServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB43CA9A1D9486ED5637742C /* BackfillServiceTests.swift */; };
 		CDDAA3EE818A11ED0D9337AC /* AllCitiesSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23864012AE9AA4481A21698F /* AllCitiesSheet.swift */; };
 		D9F49F2A3DD709A589C88C59 /* TopCitiesList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D54A9086E7CD8A895B1455 /* TopCitiesList.swift */; };
+		DFA6AB5D55F1DF7BBA1AECAB /* DataImportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34FFB29728864E0F7D0EF52E /* DataImportView.swift */; };
 		E848A7CFF1E067DB73B9B33A /* DateNormalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911CF7149B8750ACD300CE36 /* DateNormalizationTests.swift */; };
 		EAAF522E19A47CE945C3D35C /* MonthlyBreakdownChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C7CE7D50D291D8F077B727 /* MonthlyBreakdownChart.swift */; };
 		EF6A4CE9DEB6D2FAB1FB1F17 /* CaptureResultSaver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA6369ADD7129C74EDC04D7 /* CaptureResultSaver.swift */; };
@@ -75,12 +78,14 @@
 		0E0F64E8EA98CCC7B86A87F1 /* YearOverYearView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YearOverYearView.swift; sourceTree = "<group>"; };
 		108AE1705F106288F46ED85B /* Roam.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Roam.entitlements; sourceTree = "<group>"; };
 		161355E300E961AC6947F70E /* InsightsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsView.swift; sourceTree = "<group>"; };
+		1E7743148F503481970D52BA /* DataImportServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataImportServiceTests.swift; sourceTree = "<group>"; };
 		213B5349FB94E1A2C401CC74 /* ColorPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPalette.swift; sourceTree = "<group>"; };
 		23864012AE9AA4481A21698F /* AllCitiesSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllCitiesSheet.swift; sourceTree = "<group>"; };
 		29A77B7801B9C1F699E56789 /* CityDisplayFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityDisplayFormatterTests.swift; sourceTree = "<group>"; };
 		2B83452B970024E3BA1C1E06 /* DataExportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExportTests.swift; sourceTree = "<group>"; };
 		2D00E3E6D01547CE9B679052 /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
 		31F25DCF3A3939AD86AD4553 /* HighlightsGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightsGrid.swift; sourceTree = "<group>"; };
+		34FFB29728864E0F7D0EF52E /* DataImportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataImportView.swift; sourceTree = "<group>"; };
 		3DE9FD917641ADA6EA9271A4 /* CaptureSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureSource.swift; sourceTree = "<group>"; };
 		42F6EFE5C04BBCDEF9BFDDF1 /* RoamTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoamTheme.swift; sourceTree = "<group>"; };
 		451BDBADFD229CF00F91E911 /* RoamTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = RoamTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -100,6 +105,7 @@
 		7A1D3A9470466B0ACE9F8CE3 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7E0B1ECE2DC2A03A2062BCC1 /* DateNormalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateNormalization.swift; sourceTree = "<group>"; };
 		81D67A2307B78BB5B0130643 /* BackgroundTaskService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTaskService.swift; sourceTree = "<group>"; };
+		869AEC55168DE37DD3EC5624 /* DataImportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataImportService.swift; sourceTree = "<group>"; };
 		88AF720A3F1A8AFAF528D559 /* LocationValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationValidationTests.swift; sourceTree = "<group>"; };
 		911CF7149B8750ACD300CE36 /* DateNormalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateNormalizationTests.swift; sourceTree = "<group>"; };
 		96D54A9086E7CD8A895B1455 /* TopCitiesList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopCitiesList.swift; sourceTree = "<group>"; };
@@ -136,6 +142,7 @@
 				C8F6EF6C7B88382F6E50BD98 /* CaptureResultSaverTests.swift */,
 				29A77B7801B9C1F699E56789 /* CityDisplayFormatterTests.swift */,
 				2B83452B970024E3BA1C1E06 /* DataExportTests.swift */,
+				1E7743148F503481970D52BA /* DataImportServiceTests.swift */,
 				911CF7149B8750ACD300CE36 /* DateNormalizationTests.swift */,
 				88AF720A3F1A8AFAF528D559 /* LocationValidationTests.swift */,
 				DCB87FA04018026E1981F420 /* RoamTests.swift */,
@@ -153,6 +160,7 @@
 				5BA6369ADD7129C74EDC04D7 /* CaptureResultSaver.swift */,
 				7627FC571437D796D019472E /* CityDisplayFormatter.swift */,
 				67200A60234C96471025090B /* DataExportService.swift */,
+				869AEC55168DE37DD3EC5624 /* DataImportService.swift */,
 				7E0B1ECE2DC2A03A2062BCC1 /* DateNormalization.swift */,
 				BC8ABCCB1F8C28A401A4831A /* LocationCaptureService.swift */,
 				F599F069C99AF75FDF413E61 /* SignificantLocationService.swift */,
@@ -200,6 +208,7 @@
 			children = (
 				06BFA8009A22BA4D8C7357FF /* CitySearchView.swift */,
 				76EC93ED423B3CE8910B4C61 /* DataExportView.swift */,
+				34FFB29728864E0F7D0EF52E /* DataImportView.swift */,
 				73B468CC1768479756B40354 /* SettingsView.swift */,
 			);
 			path = Settings;
@@ -396,6 +405,7 @@
 				9CE4FD5AD7637F16624234D1 /* CaptureResultSaverTests.swift in Sources */,
 				5992C8E61D86C6986D989164 /* CityDisplayFormatterTests.swift in Sources */,
 				257C9005F6C1998BAA2CA774 /* DataExportTests.swift in Sources */,
+				5481C098BC3D13AC24D7EBC3 /* DataImportServiceTests.swift in Sources */,
 				E848A7CFF1E067DB73B9B33A /* DateNormalizationTests.swift in Sources */,
 				2293862100765F7BA574183A /* LocationValidationTests.swift in Sources */,
 				57C6A2A2F4154CFF796A4F06 /* RoamTests.swift in Sources */,
@@ -423,6 +433,8 @@
 				AC25A9DF61146D6642C14EB8 /* DashboardView.swift in Sources */,
 				BC3DF2657B8E2FFB90621459 /* DataExportService.swift in Sources */,
 				F064E26ED7FCC1A9353B8FE2 /* DataExportView.swift in Sources */,
+				8FCAB67D06A78874B66FF314 /* DataImportService.swift in Sources */,
+				DFA6AB5D55F1DF7BBA1AECAB /* DataImportView.swift in Sources */,
 				71B0F6BD5DE4A412AE2F0114 /* DateNormalization.swift in Sources */,
 				90FDDDF4C2346380FBFD0837 /* DayCell.swift in Sources */,
 				2710B99F9426F221581461E0 /* DayDetailSheet.swift in Sources */,

--- a/Roam/Services/DataImportService.swift
+++ b/Roam/Services/DataImportService.swift
@@ -1,0 +1,187 @@
+import Foundation
+import SwiftData
+
+enum DataImportService {
+
+    enum ImportFormat {
+        case csv
+        case json
+    }
+
+    struct ImportResult {
+        let imported: Int
+        let skipped: Int
+        let malformed: Int
+    }
+
+    struct ParsedEntry {
+        let date: Date
+        let city: String?
+        let state: String?
+        let country: String?
+        let latitude: Double?
+        let longitude: Double?
+        let capturedAt: Date?
+        let horizontalAccuracy: Double?
+    }
+
+    // MARK: - Public API
+
+    static func importFile(content: String, format: ImportFormat, into context: ModelContext) -> ImportResult {
+        let (entries, malformed) = switch format {
+        case .csv: parseCSV(content)
+        case .json: parseJSON(content)
+        }
+
+        let existingLogs = (try? context.fetch(FetchDescriptor<NightLog>())) ?? []
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        let existingDates = Set(existingLogs.map { cal.dateComponents([.year, .month, .day], from: $0.date) })
+
+        var imported = 0
+        var skipped = 0
+
+        for entry in entries {
+            let normalizedDate = DateNormalization.normalizedNightDate(from: entry.date)
+            let dateComps = cal.dateComponents([.year, .month, .day], from: normalizedDate)
+            if existingDates.contains(dateComps) {
+                skipped += 1
+                continue
+            }
+
+            let log = NightLog(
+                date: normalizedDate,
+                city: entry.city,
+                state: entry.state,
+                country: entry.country,
+                latitude: entry.latitude,
+                longitude: entry.longitude,
+                capturedAt: entry.capturedAt ?? .now,
+                horizontalAccuracy: entry.horizontalAccuracy,
+                source: .manual,
+                status: .confirmed
+            )
+            context.insert(log)
+            imported += 1
+        }
+
+        try? context.save()
+        return ImportResult(imported: imported, skipped: skipped, malformed: malformed)
+    }
+
+    // MARK: - CSV Parsing
+
+    static func parseCSV(_ content: String) -> (entries: [ParsedEntry], malformed: Int) {
+        let lines = content.replacingOccurrences(of: "\r\n", with: "\n")
+            .components(separatedBy: "\n")
+            .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+        guard lines.count > 1 else { return ([], 0) }
+
+        let formatter = ISO8601DateFormatter()
+        var entries: [ParsedEntry] = []
+        var malformed = 0
+
+        for line in lines.dropFirst() {
+            let fields = parseCSVLine(line)
+            guard fields.count >= 10,
+                  let date = formatter.date(from: fields[0]) else {
+                malformed += 1
+                continue
+            }
+
+            let entry = ParsedEntry(
+                date: date,
+                city: fields[1].nilIfEmpty,
+                state: fields[2].nilIfEmpty,
+                country: fields[3].nilIfEmpty,
+                latitude: Double(fields[4]),
+                longitude: Double(fields[5]),
+                capturedAt: formatter.date(from: fields[8]),
+                horizontalAccuracy: Double(fields[9])
+            )
+            entries.append(entry)
+        }
+
+        return (entries, malformed)
+    }
+
+    // MARK: - JSON Parsing
+
+    static func parseJSON(_ content: String) -> (entries: [ParsedEntry], malformed: Int) {
+        guard let data = content.data(using: .utf8),
+              let array = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            return ([], content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? 0 : 1)
+        }
+
+        let formatter = ISO8601DateFormatter()
+        var entries: [ParsedEntry] = []
+        var malformed = 0
+
+        for dict in array {
+            guard let dateString = dict["date"] as? String,
+                  let date = formatter.date(from: dateString) else {
+                malformed += 1
+                continue
+            }
+
+            let entry = ParsedEntry(
+                date: date,
+                city: dict["city"] as? String,
+                state: dict["state"] as? String,
+                country: dict["country"] as? String,
+                latitude: dict["latitude"] as? Double,
+                longitude: dict["longitude"] as? Double,
+                capturedAt: (dict["captured_at"] as? String).flatMap { formatter.date(from: $0) },
+                horizontalAccuracy: dict["accuracy"] as? Double
+            )
+            entries.append(entry)
+        }
+
+        return (entries, malformed)
+    }
+
+    // MARK: - CSV Line Parser
+
+    private static func parseCSVLine(_ line: String) -> [String] {
+        var fields: [String] = []
+        var current = ""
+        var inQuotes = false
+        var i = line.startIndex
+
+        while i < line.endIndex {
+            let char = line[i]
+            if inQuotes {
+                if char == "\"" {
+                    let next = line.index(after: i)
+                    if next < line.endIndex && line[next] == "\"" {
+                        current.append("\"")
+                        i = line.index(after: next)
+                        continue
+                    } else {
+                        inQuotes = false
+                    }
+                } else {
+                    current.append(char)
+                }
+            } else {
+                if char == "\"" {
+                    inQuotes = true
+                } else if char == "," {
+                    fields.append(current)
+                    current = ""
+                } else {
+                    current.append(char)
+                }
+            }
+            i = line.index(after: i)
+        }
+        fields.append(current)
+        return fields
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/Roam/Views/Settings/DataImportView.swift
+++ b/Roam/Views/Settings/DataImportView.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+import SwiftData
+import UniformTypeIdentifiers
+
+struct DataImportView: View {
+    @Environment(\.modelContext) private var context
+    @State private var showingFilePicker = false
+    @State private var importResult: DataImportService.ImportResult?
+    @State private var showingResult = false
+    @State private var importError: String?
+    @State private var showingError = false
+
+    var body: some View {
+        Form {
+            Section {
+                Text("Import NightLog entries from a CSV or JSON file previously exported from Roam.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section {
+                Button("Choose File") {
+                    showingFilePicker = true
+                }
+            }
+        }
+        .navigationTitle("Import Data")
+        .fileImporter(
+            isPresented: $showingFilePicker,
+            allowedContentTypes: [.commaSeparatedText, .json],
+            allowsMultipleSelection: false
+        ) { result in
+            handleFileImport(result)
+        }
+        .alert("Import Complete", isPresented: $showingResult) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            if let result = importResult {
+                Text(importSummary(result))
+            }
+        }
+        .alert("Import Failed", isPresented: $showingError) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(importError ?? "An unknown error occurred.")
+        }
+    }
+
+    private func handleFileImport(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            guard let url = urls.first else { return }
+            guard url.startAccessingSecurityScopedResource() else {
+                importError = "Unable to access the selected file."
+                showingError = true
+                return
+            }
+            defer { url.stopAccessingSecurityScopedResource() }
+
+            do {
+                let content = try String(contentsOf: url, encoding: .utf8)
+                let format: DataImportService.ImportFormat =
+                    url.pathExtension.lowercased() == "json" ? .json : .csv
+                importResult = DataImportService.importFile(content: content, format: format, into: context)
+                showingResult = true
+            } catch {
+                importError = error.localizedDescription
+                showingError = true
+            }
+
+        case .failure(let error):
+            importError = error.localizedDescription
+            showingError = true
+        }
+    }
+
+    private func importSummary(_ result: DataImportService.ImportResult) -> String {
+        var parts = ["\(result.imported) entries imported", "\(result.skipped) skipped (duplicates)"]
+        if result.malformed > 0 {
+            parts.append("\(result.malformed) malformed rows")
+        }
+        return parts.joined(separator: ", ")
+    }
+}

--- a/Roam/Views/Settings/SettingsView.swift
+++ b/Roam/Views/Settings/SettingsView.swift
@@ -108,6 +108,9 @@ struct SettingsView: View {
                     NavigationLink("Export Data") {
                         DataExportView()
                     }
+                    NavigationLink("Import Data") {
+                        DataImportView()
+                    }
                 }
 
                 Section("About") {

--- a/RoamTests/DataImportServiceTests.swift
+++ b/RoamTests/DataImportServiceTests.swift
@@ -1,0 +1,304 @@
+import XCTest
+import SwiftData
+@testable import Roam
+
+@MainActor
+final class DataImportServiceTests: XCTestCase {
+
+    var container: ModelContainer!
+    var context: ModelContext!
+
+    override func setUp() async throws {
+        let cloudConfig = ModelConfiguration(
+            "cloud",
+            schema: Schema([NightLog.self, CityColor.self]),
+            isStoredInMemoryOnly: true,
+            cloudKitDatabase: .none
+        )
+        let localConfig = ModelConfiguration(
+            "local",
+            schema: Schema([UserSettings.self]),
+            isStoredInMemoryOnly: true,
+            cloudKitDatabase: .none
+        )
+        container = try ModelContainer(
+            for: NightLog.self, CityColor.self, UserSettings.self,
+            configurations: cloudConfig, localConfig
+        )
+        context = container.mainContext
+    }
+
+    // MARK: - CSV Parsing
+
+    func testParseValidCSV() {
+        let csv = [
+            "date,city,state,country,latitude,longitude,source,status,captured_at,accuracy",
+            "\"2026-01-15T12:00:00Z\",\"Austin\",\"TX\",\"US\",\"30.2672\",\"-97.7431\",\"automatic\",\"confirmed\",\"2026-01-15T02:00:00Z\",\"50\"",
+            "\"2026-01-16T12:00:00Z\",\"NYC\",\"NY\",\"US\",\"40.7128\",\"-74.006\",\"automatic\",\"confirmed\",\"2026-01-16T02:00:00Z\",\"30\"",
+            "\"2026-01-17T12:00:00Z\",\"LA\",\"CA\",\"US\",\"34.0522\",\"-118.2437\",\"manual\",\"manual\",\"2026-01-17T12:00:00Z\",\"100\"",
+            "\"2026-01-18T12:00:00Z\",\"\",\"\",\"\",\"\",\"\",\"automatic\",\"unresolved\",\"2026-01-18T02:00:00Z\",\"\"",
+            "\"2026-01-19T12:00:00Z\",\"Chicago\",\"IL\",\"US\",\"41.8781\",\"-87.6298\",\"automatic\",\"confirmed\",\"2026-01-19T02:00:00Z\",\"25\""
+        ].joined(separator: "\n")
+
+        let (entries, malformed) = DataImportService.parseCSV(csv)
+
+        XCTAssertEqual(entries.count, 5)
+        XCTAssertEqual(malformed, 0)
+
+        XCTAssertEqual(entries[0].city, "Austin")
+        XCTAssertEqual(entries[0].state, "TX")
+        XCTAssertEqual(entries[0].country, "US")
+        XCTAssertEqual(entries[0].latitude, 30.2672)
+        XCTAssertEqual(entries[0].longitude, -97.7431)
+
+        // Empty fields should be nil
+        XCTAssertNil(entries[3].city)
+        XCTAssertNil(entries[3].latitude)
+        XCTAssertNil(entries[3].horizontalAccuracy)
+    }
+
+    func testParseCSVWithMalformedRows() {
+        let csv = [
+            "date,city,state,country,latitude,longitude,source,status,captured_at,accuracy",
+            "\"2026-01-15T12:00:00Z\",\"Austin\",\"TX\",\"US\",\"30.2672\",\"-97.7431\",\"automatic\",\"confirmed\",\"2026-01-15T02:00:00Z\",\"50\"",
+            "not a valid row",
+            "\"bad-date\",\"Austin\",\"TX\",\"US\",\"30\",\"97\",\"auto\",\"confirmed\",\"2026-01-15T02:00:00Z\",\"50\""
+        ].joined(separator: "\n")
+
+        let (entries, malformed) = DataImportService.parseCSV(csv)
+
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(malformed, 2)
+    }
+
+    func testParseCSVHeaderOnly() {
+        let csv = "date,city,state,country,latitude,longitude,source,status,captured_at,accuracy"
+
+        let (entries, malformed) = DataImportService.parseCSV(csv)
+
+        XCTAssertEqual(entries.count, 0)
+        XCTAssertEqual(malformed, 0)
+    }
+
+    func testParseCSVEmpty() {
+        let (entries, malformed) = DataImportService.parseCSV("")
+
+        XCTAssertEqual(entries.count, 0)
+        XCTAssertEqual(malformed, 0)
+    }
+
+    func testParseCSVWithEscapedQuotes() {
+        let csv = [
+            "date,city,state,country,latitude,longitude,source,status,captured_at,accuracy",
+            "\"2026-01-15T12:00:00Z\",\"City with \"\"quotes\"\"\",\"TX\",\"US\",\"30\",\"97\",\"manual\",\"confirmed\",\"2026-01-15T12:00:00Z\",\"50\""
+        ].joined(separator: "\n")
+
+        let (entries, malformed) = DataImportService.parseCSV(csv)
+
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(malformed, 0)
+        XCTAssertEqual(entries[0].city, "City with \"quotes\"")
+    }
+
+    // MARK: - JSON Parsing
+
+    func testParseValidJSON() {
+        let json = """
+[
+    {
+        "date": "2026-01-15T12:00:00Z",
+        "city": "Austin",
+        "state": "TX",
+        "country": "US",
+        "latitude": 30.2672,
+        "longitude": -97.7431,
+        "source": "automatic",
+        "status": "confirmed",
+        "captured_at": "2026-01-15T02:00:00Z",
+        "accuracy": 50.0
+    },
+    {
+        "date": "2026-01-16T12:00:00Z",
+        "city": "NYC",
+        "state": "NY",
+        "country": "US",
+        "latitude": 40.7128,
+        "longitude": -74.006,
+        "source": "automatic",
+        "status": "confirmed",
+        "captured_at": "2026-01-16T02:00:00Z",
+        "accuracy": 30.0
+    },
+    {
+        "date": "2026-01-17T12:00:00Z",
+        "source": "automatic",
+        "status": "unresolved",
+        "captured_at": "2026-01-17T02:00:00Z"
+    },
+    {
+        "date": "2026-01-18T12:00:00Z",
+        "city": "Chicago",
+        "state": "IL",
+        "country": "US",
+        "source": "automatic",
+        "status": "confirmed",
+        "captured_at": "2026-01-18T02:00:00Z"
+    },
+    {
+        "date": "2026-01-19T12:00:00Z",
+        "city": "LA",
+        "state": "CA",
+        "country": "US",
+        "latitude": 34.0522,
+        "longitude": -118.2437,
+        "source": "manual",
+        "status": "manual",
+        "captured_at": "2026-01-19T12:00:00Z",
+        "accuracy": 100.0
+    }
+]
+"""
+
+        let (entries, malformed) = DataImportService.parseJSON(json)
+
+        XCTAssertEqual(entries.count, 5)
+        XCTAssertEqual(malformed, 0)
+
+        XCTAssertEqual(entries[0].city, "Austin")
+        XCTAssertEqual(entries[0].latitude, 30.2672)
+
+        // Entry with no optional fields
+        XCTAssertNil(entries[2].city)
+        XCTAssertNil(entries[2].latitude)
+    }
+
+    func testParseJSONMissingDate() {
+        let json = """
+[
+    {"city": "Austin", "source": "automatic", "status": "confirmed", "captured_at": "2026-01-15T02:00:00Z"},
+    {"date": "2026-01-16T12:00:00Z", "city": "NYC", "source": "automatic", "status": "confirmed", "captured_at": "2026-01-16T02:00:00Z"}
+]
+"""
+
+        let (entries, malformed) = DataImportService.parseJSON(json)
+
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(malformed, 1)
+        XCTAssertEqual(entries[0].city, "NYC")
+    }
+
+    func testParseJSONWithExtraKeys() {
+        let json = """
+[{"date": "2026-01-15T12:00:00Z", "city": "Austin", "source": "auto", "status": "confirmed", "captured_at": "2026-01-15T02:00:00Z", "extra_field": "ignored"}]
+"""
+
+        let (entries, malformed) = DataImportService.parseJSON(json)
+
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(malformed, 0)
+        XCTAssertEqual(entries[0].city, "Austin")
+    }
+
+    func testParseJSONEmpty() {
+        let (entries, malformed) = DataImportService.parseJSON("[]")
+
+        XCTAssertEqual(entries.count, 0)
+        XCTAssertEqual(malformed, 0)
+    }
+
+    // MARK: - Import with Duplicate Detection
+
+    func testImportSkipsDuplicates() {
+        // Pre-insert a log for Jan 15
+        let existingLog = NightLog(
+            date: noonUTC(2026, 1, 15),
+            city: "Austin",
+            state: "TX",
+            country: "US",
+            capturedAt: noonUTC(2026, 1, 15)
+        )
+        context.insert(existingLog)
+        try! context.save()
+
+        let csv = [
+            "date,city,state,country,latitude,longitude,source,status,captured_at,accuracy",
+            "\"2026-01-15T12:00:00Z\",\"NYC\",\"NY\",\"US\",\"40\",\"74\",\"automatic\",\"confirmed\",\"2026-01-15T02:00:00Z\",\"50\"",
+            "\"2026-01-16T12:00:00Z\",\"LA\",\"CA\",\"US\",\"34\",\"118\",\"automatic\",\"confirmed\",\"2026-01-16T02:00:00Z\",\"50\""
+        ].joined(separator: "\n")
+
+        let result = DataImportService.importFile(content: csv, format: .csv, into: context)
+
+        XCTAssertEqual(result.imported, 1)
+        XCTAssertEqual(result.skipped, 1)
+        XCTAssertEqual(result.malformed, 0)
+
+        // Verify the existing Austin entry wasn't overwritten
+        let allLogs = try! context.fetch(FetchDescriptor<NightLog>(sortBy: [SortDescriptor(\NightLog.date)]))
+        XCTAssertEqual(allLogs.count, 2)
+        XCTAssertEqual(allLogs[0].city, "Austin") // original preserved
+        XCTAssertEqual(allLogs[1].city, "LA") // new one imported
+    }
+
+    func testImportSetsSourceToManual() {
+        let csv = [
+            "date,city,state,country,latitude,longitude,source,status,captured_at,accuracy",
+            "\"2026-01-15T12:00:00Z\",\"Austin\",\"TX\",\"US\",\"30\",\"97\",\"automatic\",\"confirmed\",\"2026-01-15T02:00:00Z\",\"50\""
+        ].joined(separator: "\n")
+
+        let result = DataImportService.importFile(content: csv, format: .csv, into: context)
+
+        XCTAssertEqual(result.imported, 1)
+
+        let logs = try! context.fetch(FetchDescriptor<NightLog>())
+        XCTAssertEqual(logs[0].source, .manual)
+        XCTAssertEqual(logs[0].status, .confirmed)
+    }
+
+    func testImportJSONFile() {
+        let json = """
+[
+    {"date": "2026-01-15T12:00:00Z", "city": "Austin", "state": "TX", "country": "US", "source": "automatic", "status": "confirmed", "captured_at": "2026-01-15T02:00:00Z"},
+    {"date": "2026-01-16T12:00:00Z", "city": "NYC", "state": "NY", "country": "US", "source": "automatic", "status": "confirmed", "captured_at": "2026-01-16T02:00:00Z"}
+]
+"""
+
+        let result = DataImportService.importFile(content: json, format: .json, into: context)
+
+        XCTAssertEqual(result.imported, 2)
+        XCTAssertEqual(result.skipped, 0)
+        XCTAssertEqual(result.malformed, 0)
+
+        let logs = try! context.fetch(FetchDescriptor<NightLog>(sortBy: [SortDescriptor(\NightLog.date)]))
+        XCTAssertEqual(logs.count, 2)
+        XCTAssertEqual(logs[0].city, "Austin")
+        XCTAssertEqual(logs[1].city, "NYC")
+    }
+
+    func testImportCombinesMalformedAndDuplicates() {
+        // Pre-insert for Jan 15
+        let existing = NightLog(date: noonUTC(2026, 1, 15), capturedAt: noonUTC(2026, 1, 15))
+        context.insert(existing)
+        try! context.save()
+
+        let csv = [
+            "date,city,state,country,latitude,longitude,source,status,captured_at,accuracy",
+            "\"2026-01-15T12:00:00Z\",\"Austin\",\"TX\",\"US\",\"30\",\"97\",\"auto\",\"confirmed\",\"2026-01-15T02:00:00Z\",\"50\"",
+            "bad row",
+            "\"2026-01-16T12:00:00Z\",\"NYC\",\"NY\",\"US\",\"40\",\"74\",\"auto\",\"confirmed\",\"2026-01-16T02:00:00Z\",\"30\""
+        ].joined(separator: "\n")
+
+        let result = DataImportService.importFile(content: csv, format: .csv, into: context)
+
+        XCTAssertEqual(result.imported, 1)
+        XCTAssertEqual(result.skipped, 1)
+        XCTAssertEqual(result.malformed, 1)
+    }
+
+    // MARK: - Helpers
+
+    private func noonUTC(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal.date(from: DateComponents(year: year, month: month, day: day, hour: 12))!
+    }
+}


### PR DESCRIPTION
## Summary
- Add `DataImportService` with CSV/JSON parsing, date normalization, and duplicate detection (skips entries whose date already exists)
- Add `DataImportView` with file picker (`fileImporter`) and result summary alert (imported/skipped/malformed counts)
- Add "Import Data" link in Settings alongside existing Export
- 13 unit tests covering both formats, malformed rows, duplicates, and edge cases

## Test plan
- [x] Unit tests: valid CSV/JSON parsing, malformed rows, empty files, header-only, escaped quotes
- [x] Unit tests: duplicate date skipping, source set to `.manual`, combined malformed+duplicate counts
- [ ] Manual QA: export all entries, delete a few, re-import the file, verify correct count restored
- [ ] Edge case: import empty file, file with only header row

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)