### PR TITLE
feat: Insights legend and chart improvements

### DIFF
--- a/Roam/Views/Insights/MonthlyBreakdownChart.swift
+++ b/Roam/Views/Insights/MonthlyBreakdownChart.swift
@@ -7,6 +7,44 @@ struct MonthlyBreakdownChart: View {
 
     private let monthLabels = Calendar.current.veryShortMonthSymbols
 
+    private var legendEntries: [(key: String, label: String, color: Color)] {
+        var seen = Set<String>()
+        var entries: [(key: String, label: String, color: Color)] = []
+        var hasOther = false
+
+        for month in breakdown {
+            for entry in month.cityDays {
+                guard !seen.contains(entry.cityKey) else { continue }
+                seen.insert(entry.cityKey)
+
+                if let cc = cityColors.first(where: { $0.cityKey == entry.cityKey }),
+                   cc.colorIndex < ColorPalette.maxColoredCities {
+                    let parts = entry.cityKey.split(separator: "|")
+                    let city = parts.first.map(String.init)
+                    let state = parts.count > 1 ? String(parts[1]) : nil
+                    let country = parts.count > 2 ? String(parts[2]) : nil
+                    let label = CityDisplayFormatter.format(city: city, state: state, country: country)
+                    entries.append((key: entry.cityKey, label: label, color: ColorPalette.color(for: cc.colorIndex)))
+                } else {
+                    hasOther = true
+                }
+            }
+        }
+
+        // Sort by color index for consistent ordering
+        entries.sort { a, b in
+            let aIndex = cityColors.first(where: { $0.cityKey == a.key })?.colorIndex ?? Int.max
+            let bIndex = cityColors.first(where: { $0.cityKey == b.key })?.colorIndex ?? Int.max
+            return aIndex < bIndex
+        }
+
+        if hasOther {
+            entries.append((key: "other", label: "Other", color: ColorPalette.otherColor))
+        }
+
+        return entries
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Monthly Breakdown")
@@ -23,11 +61,26 @@ struct MonthlyBreakdownChart: View {
                     }
                 }
             }
+            .chartYScale(domain: 0...31)
             .frame(height: 180)
             .chartXAxis {
                 AxisMarks(values: .automatic) { _ in
                     AxisValueLabel()
                         .font(.caption2)
+                }
+            }
+
+            // Legend
+            FlowLayout(spacing: 8) {
+                ForEach(legendEntries, id: \.key) { entry in
+                    HStack(spacing: 4) {
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(entry.color)
+                            .frame(width: 10, height: 10)
+                        Text(entry.label)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
         }
@@ -38,5 +91,53 @@ struct MonthlyBreakdownChart: View {
             return .gray
         }
         return ColorPalette.color(for: cc.colorIndex)
+    }
+}
+
+private struct FlowLayout: Layout {
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let rows = computeRows(proposal: proposal, subviews: subviews)
+        var height: CGFloat = 0
+        for (i, row) in rows.enumerated() {
+            let rowHeight = row.map { subviews[$0].sizeThatFits(.unspecified).height }.max() ?? 0
+            height += rowHeight
+            if i > 0 { height += spacing }
+        }
+        return CGSize(width: proposal.width ?? 0, height: height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let rows = computeRows(proposal: proposal, subviews: subviews)
+        var y = bounds.minY
+        for (i, row) in rows.enumerated() {
+            if i > 0 { y += spacing }
+            var x = bounds.minX
+            let rowHeight = row.map { subviews[$0].sizeThatFits(.unspecified).height }.max() ?? 0
+            for index in row {
+                let size = subviews[index].sizeThatFits(.unspecified)
+                subviews[index].place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
+                x += size.width + spacing
+            }
+            y += rowHeight
+        }
+    }
+
+    private func computeRows(proposal: ProposedViewSize, subviews: Subviews) -> [[Int]] {
+        let maxWidth = proposal.width ?? .infinity
+        var rows: [[Int]] = [[]]
+        var currentWidth: CGFloat = 0
+
+        for (index, subview) in subviews.enumerated() {
+            let size = subview.sizeThatFits(.unspecified)
+            if currentWidth + size.width > maxWidth && !rows[rows.count - 1].isEmpty {
+                rows.append([])
+                currentWidth = 0
+            }
+            rows[rows.count - 1].append(index)
+            currentWidth += size.width + spacing
+        }
+        return rows
     }
 }

--- a/Roam/Views/Timeline/TimelineView.swift
+++ b/Roam/Views/Timeline/TimelineView.swift
@@ -102,13 +102,18 @@ struct TimelineView: View {
     }
 
     private var legend: some View {
-        let usedKeys = Set(allLogs.compactMap {
-            $0.status != .unresolved ? CityDisplayFormatter.cityKey(city: $0.city, state: $0.state, country: $0.country) : nil
-        })
+        var keyCounts: [String: Int] = [:]
+        for log in allLogs where log.status != .unresolved {
+            let key = CityDisplayFormatter.cityKey(city: log.city, state: log.state, country: log.country)
+            keyCounts[key, default: 0] += 1
+        }
+        let sorted = cityColors
+            .filter { keyCounts[$0.cityKey] != nil }
+            .sorted { keyCounts[$0.cityKey, default: 0] > keyCounts[$1.cityKey, default: 0] }
 
         return ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 12) {
-                ForEach(cityColors.filter { usedKeys.contains($0.cityKey) }, id: \.cityKey) { cc in
+                ForEach(sorted, id: \.cityKey) { cc in
                     HStack(spacing: 4) {
                         RoundedRectangle(cornerRadius: 2)
                             .fill(ColorPalette.color(for: cc.colorIndex))


### PR DESCRIPTION
## Summary
- Add city color legend to Monthly Breakdown chart, derived from current data with flow-wrap layout
- Cap y-axis at 31 (max days in a month) for consistent visual scale
- Sort Timeline legend by frequency (most nights first)

## Test plan
- [ ] Insights: verify legend shows correct city colors matching chart bars
- [ ] Insights: verify y-axis tops at 31 regardless of data
- [ ] Insights: verify "Other" appears in legend when 6+ cities exist
- [ ] Timeline: verify legend ordered by most frequent city first

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)