### PR TITLE
Deduplicate NightLog entries after CloudKit sync

### DIFF
--- a/Roam.xcodeproj/project.pbxproj
+++ b/Roam.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		9F33C43995795018E6000775 /* AnalyticsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DDD65758488CE7F62C1F58 /* AnalyticsServiceTests.swift */; };
 		9F4F09384F6FBBCF75ABC9A1 /* CaptureSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE9FD917641ADA6EA9271A4 /* CaptureSource.swift */; };
 		AC25A9DF61146D6642C14EB8 /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D00E3E6D01547CE9B679052 /* DashboardView.swift */; };
+		AF8FE20EBFF81E858C424C26 /* DeduplicationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E07135CDB115BE04D02FD04 /* DeduplicationService.swift */; };
 		B3B65F4760C913CB20F71ABF /* TimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72CE241E3B8CDD29B35059E /* TimelineView.swift */; };
 		B9EEE152B2DA6466212A6164 /* UnresolvedBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9FCD0FC937244CF77D549C4 /* UnresolvedBanner.swift */; };
 		BB6552613AEC50EEF56580EC /* UnresolvedResolutionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F7662D32B82233CD23108F /* UnresolvedResolutionView.swift */; };
@@ -62,6 +63,7 @@
 		EF6A4CE9DEB6D2FAB1FB1F17 /* CaptureResultSaver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA6369ADD7129C74EDC04D7 /* CaptureResultSaver.swift */; };
 		EFA488C0CDDB8D136ECF393D /* UnresolvedFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5F214DCE81E9A4C3C1E11D /* UnresolvedFilterTests.swift */; };
 		F064E26ED7FCC1A9353B8FE2 /* DataExportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76EC93ED423B3CE8910B4C61 /* DataExportView.swift */; };
+		F3AD6860617159F9D6F8FFF3 /* DeduplicationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C11F9644281708616F2268 /* DeduplicationServiceTests.swift */; };
 		F4787C5C6FC3DD7F1544085E /* YearDotGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409B51C0F0DD1105703B77C0 /* YearDotGridView.swift */; };
 		F480F4976E853181D845E873 /* CurrentCityBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC4155DEDC8A5F93BAE9BA02 /* CurrentCityBanner.swift */; };
 /* End PBXBuildFile section */
@@ -93,6 +95,7 @@
 		3DE9FD917641ADA6EA9271A4 /* CaptureSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureSource.swift; sourceTree = "<group>"; };
 		409B51C0F0DD1105703B77C0 /* YearDotGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YearDotGridView.swift; sourceTree = "<group>"; };
 		42F6EFE5C04BBCDEF9BFDDF1 /* RoamTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoamTheme.swift; sourceTree = "<group>"; };
+		43C11F9644281708616F2268 /* DeduplicationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeduplicationServiceTests.swift; sourceTree = "<group>"; };
 		451BDBADFD229CF00F91E911 /* RoamTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = RoamTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4D7FF89B107B4B4154B20D9C /* DayCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayCell.swift; sourceTree = "<group>"; };
 		4F5CA8FAA3547C6DCBCBBE01 /* LogStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogStatus.swift; sourceTree = "<group>"; };
@@ -108,6 +111,7 @@
 		76EC93ED423B3CE8910B4C61 /* DataExportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExportView.swift; sourceTree = "<group>"; };
 		778687BCAF748015DFE68915 /* AnalyticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsService.swift; sourceTree = "<group>"; };
 		7A1D3A9470466B0ACE9F8CE3 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		7E07135CDB115BE04D02FD04 /* DeduplicationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeduplicationService.swift; sourceTree = "<group>"; };
 		7E0B1ECE2DC2A03A2062BCC1 /* DateNormalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateNormalization.swift; sourceTree = "<group>"; };
 		81D67A2307B78BB5B0130643 /* BackgroundTaskService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTaskService.swift; sourceTree = "<group>"; };
 		85746F2EC5BF766F57464131 /* MiniMonthGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniMonthGridView.swift; sourceTree = "<group>"; };
@@ -152,6 +156,7 @@
 				2B83452B970024E3BA1C1E06 /* DataExportTests.swift */,
 				1E7743148F503481970D52BA /* DataImportServiceTests.swift */,
 				911CF7149B8750ACD300CE36 /* DateNormalizationTests.swift */,
+				43C11F9644281708616F2268 /* DeduplicationServiceTests.swift */,
 				88AF720A3F1A8AFAF528D559 /* LocationValidationTests.swift */,
 				DCB87FA04018026E1981F420 /* RoamTests.swift */,
 				DC20F392092EA72D0AAD7AC4 /* SignificantLocationServiceTests.swift */,
@@ -171,6 +176,7 @@
 				67200A60234C96471025090B /* DataExportService.swift */,
 				869AEC55168DE37DD3EC5624 /* DataImportService.swift */,
 				7E0B1ECE2DC2A03A2062BCC1 /* DateNormalization.swift */,
+				7E07135CDB115BE04D02FD04 /* DeduplicationService.swift */,
 				BC8ABCCB1F8C28A401A4831A /* LocationCaptureService.swift */,
 				F599F069C99AF75FDF413E61 /* SignificantLocationService.swift */,
 				B645BA3A5C4B184DA801D31B /* UnresolvedFilter.swift */,
@@ -419,6 +425,7 @@
 				257C9005F6C1998BAA2CA774 /* DataExportTests.swift in Sources */,
 				5481C098BC3D13AC24D7EBC3 /* DataImportServiceTests.swift in Sources */,
 				E848A7CFF1E067DB73B9B33A /* DateNormalizationTests.swift in Sources */,
+				F3AD6860617159F9D6F8FFF3 /* DeduplicationServiceTests.swift in Sources */,
 				2293862100765F7BA574183A /* LocationValidationTests.swift in Sources */,
 				57C6A2A2F4154CFF796A4F06 /* RoamTests.swift in Sources */,
 				C95DE86E5415A367B3247F47 /* SignificantLocationServiceTests.swift in Sources */,
@@ -451,6 +458,7 @@
 				71B0F6BD5DE4A412AE2F0114 /* DateNormalization.swift in Sources */,
 				90FDDDF4C2346380FBFD0837 /* DayCell.swift in Sources */,
 				2710B99F9426F221581461E0 /* DayDetailSheet.swift in Sources */,
+				AF8FE20EBFF81E858C424C26 /* DeduplicationService.swift in Sources */,
 				67179C62483A18ECA29E1BD6 /* GrainBackground.swift in Sources */,
 				1F83049070C1A069782B8963 /* HighlightsGrid.swift in Sources */,
 				45FEA24C9A0F3D0977A94A82 /* InsightsView.swift in Sources */,

--- a/Roam/ContentView.swift
+++ b/Roam/ContentView.swift
@@ -80,6 +80,7 @@ struct ContentView: View {
             .task {
                 await attemptForegroundCapture()
                 BackfillService.backfillMissedNights(context: context)
+                DeduplicationService.deduplicateNightLogs(context: context)
                 assignMissingColors()
             }
         }

--- a/Roam/Services/DeduplicationService.swift
+++ b/Roam/Services/DeduplicationService.swift
@@ -1,0 +1,48 @@
+import Foundation
+import os
+import SwiftData
+
+enum DeduplicationService {
+
+    private static let logger = Logger(subsystem: "com.naoyawada.roam", category: "Deduplication")
+
+    /// Remove duplicate NightLog entries that share the same date.
+    /// Keeps the best entry per priority: confirmed > manual > unresolved,
+    /// then most recent capturedAt as tiebreaker.
+    @MainActor
+    static func deduplicateNightLogs(context: ModelContext) {
+        let allLogs = (try? context.fetch(FetchDescriptor<NightLog>())) ?? []
+
+        let grouped = Dictionary(grouping: allLogs) { $0.date }
+
+        var deletedCount = 0
+        for (_, logs) in grouped where logs.count > 1 {
+            let sorted = logs.sorted { a, b in
+                let aPriority = statusPriority(a.status)
+                let bPriority = statusPriority(b.status)
+                if aPriority != bPriority {
+                    return aPriority < bPriority
+                }
+                return a.capturedAt > b.capturedAt
+            }
+
+            for log in sorted.dropFirst() {
+                context.delete(log)
+                deletedCount += 1
+            }
+        }
+
+        if deletedCount > 0 {
+            try? context.save()
+            logger.info("Deduplicated \(deletedCount) NightLog entries")
+        }
+    }
+
+    private static func statusPriority(_ status: LogStatus) -> Int {
+        switch status {
+        case .confirmed: return 0
+        case .manual: return 1
+        case .unresolved: return 2
+        }
+    }
+}

--- a/RoamTests/DeduplicationServiceTests.swift
+++ b/RoamTests/DeduplicationServiceTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+import SwiftData
+@testable import Roam
+
+@MainActor
+final class DeduplicationServiceTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+
+    override func setUp() async throws {
+        let schema = Schema([NightLog.self, CityColor.self])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        container = try ModelContainer(for: schema, configurations: [config])
+        context = container.mainContext
+    }
+
+    func testNoDuplicates_noChanges() {
+        let log1 = NightLog(date: noonUTC(2026, 3, 15), city: "Atlanta", status: .confirmed)
+        let log2 = NightLog(date: noonUTC(2026, 3, 16), city: "Atlanta", status: .confirmed)
+        context.insert(log1)
+        context.insert(log2)
+        try! context.save()
+
+        DeduplicationService.deduplicateNightLogs(context: context)
+
+        let logs = try! context.fetch(FetchDescriptor<NightLog>(sortBy: [SortDescriptor(\.date)]))
+        XCTAssertEqual(logs.count, 2)
+    }
+
+    func testTwoConfirmedSameDate_keepsMostRecentCapturedAt() {
+        let date = noonUTC(2026, 3, 15)
+        let older = NightLog(date: date, city: "Atlanta", capturedAt: captureDate(2026, 3, 16, hour: 2), status: .confirmed)
+        let newer = NightLog(date: date, city: "Atlanta", capturedAt: captureDate(2026, 3, 16, hour: 5), status: .confirmed)
+        context.insert(older)
+        context.insert(newer)
+        try! context.save()
+
+        DeduplicationService.deduplicateNightLogs(context: context)
+
+        let logs = try! context.fetch(FetchDescriptor<NightLog>())
+        XCTAssertEqual(logs.count, 1)
+        XCTAssertEqual(logs[0].capturedAt, newer.capturedAt)
+    }
+
+    func testConfirmedBeatsUnresolved() {
+        let date = noonUTC(2026, 3, 15)
+        let unresolved = NightLog(date: date, status: .unresolved)
+        let confirmed = NightLog(date: date, city: "Atlanta", status: .confirmed)
+        context.insert(unresolved)
+        context.insert(confirmed)
+        try! context.save()
+
+        DeduplicationService.deduplicateNightLogs(context: context)
+
+        let logs = try! context.fetch(FetchDescriptor<NightLog>())
+        XCTAssertEqual(logs.count, 1)
+        XCTAssertEqual(logs[0].status, .confirmed)
+        XCTAssertEqual(logs[0].city, "Atlanta")
+    }
+
+    func testManualBeatsUnresolved() {
+        let date = noonUTC(2026, 3, 15)
+        let unresolved = NightLog(date: date, status: .unresolved)
+        let manual = NightLog(date: date, city: "Asheville", status: .manual)
+        context.insert(unresolved)
+        context.insert(manual)
+        try! context.save()
+
+        DeduplicationService.deduplicateNightLogs(context: context)
+
+        let logs = try! context.fetch(FetchDescriptor<NightLog>())
+        XCTAssertEqual(logs.count, 1)
+        XCTAssertEqual(logs[0].status, .manual)
+        XCTAssertEqual(logs[0].city, "Asheville")
+    }
+
+    func testThreeDuplicates_keepsOnlyOne() {
+        let date = noonUTC(2026, 3, 15)
+        let log1 = NightLog(date: date, city: "Atlanta", capturedAt: captureDate(2026, 3, 16, hour: 2), status: .confirmed)
+        let log2 = NightLog(date: date, city: "Atlanta", capturedAt: captureDate(2026, 3, 16, hour: 3), status: .confirmed)
+        let log3 = NightLog(date: date, city: "Atlanta", capturedAt: captureDate(2026, 3, 16, hour: 5), status: .confirmed)
+        context.insert(log1)
+        context.insert(log2)
+        context.insert(log3)
+        try! context.save()
+
+        DeduplicationService.deduplicateNightLogs(context: context)
+
+        let logs = try! context.fetch(FetchDescriptor<NightLog>())
+        XCTAssertEqual(logs.count, 1)
+        XCTAssertEqual(logs[0].capturedAt, log3.capturedAt)
+    }
+
+    func testMultipleDatesWithMixedDuplicates() {
+        let date1 = noonUTC(2026, 3, 15)
+        let date2 = noonUTC(2026, 3, 16)
+
+        let d1confirmed = NightLog(date: date1, city: "Atlanta", status: .confirmed)
+        let d1unresolved = NightLog(date: date1, status: .unresolved)
+
+        let d2older = NightLog(date: date2, city: "Asheville", capturedAt: captureDate(2026, 3, 17, hour: 2), status: .confirmed)
+        let d2newer = NightLog(date: date2, city: "Asheville", capturedAt: captureDate(2026, 3, 17, hour: 5), status: .confirmed)
+
+        context.insert(d1confirmed)
+        context.insert(d1unresolved)
+        context.insert(d2older)
+        context.insert(d2newer)
+        try! context.save()
+
+        DeduplicationService.deduplicateNightLogs(context: context)
+
+        let logs = try! context.fetch(FetchDescriptor<NightLog>(sortBy: [SortDescriptor(\.date)]))
+        XCTAssertEqual(logs.count, 2)
+        XCTAssertEqual(logs[0].date, date1)
+        XCTAssertEqual(logs[0].status, .confirmed)
+        XCTAssertEqual(logs[1].date, date2)
+        XCTAssertEqual(logs[1].capturedAt, d2newer.capturedAt)
+    }
+
+    // MARK: - Helpers
+
+    private func noonUTC(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal.date(from: DateComponents(year: year, month: month, day: day, hour: 12))!
+    }
+
+    private func captureDate(_ year: Int, _ month: Int, _ day: Int, hour: Int) -> Date {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal.date(from: DateComponents(year: year, month: month, day: day, hour: hour))!
+    }
+}


### PR DESCRIPTION
## Summary
- Add `DeduplicationService` that runs on every app launch, groups NightLogs by date, and removes duplicates — keeping the best entry per priority (confirmed > manual > unresolved, then most recent capturedAt)
- Wired into `ContentView.task` after backfill and before color assignment
- 6 unit tests with in-memory SwiftData containers

## Test plan
- [x] 74 unit tests passing, 0 failures
- [ ] Manual: rebuild app, sync from CloudKit, verify day counts are correct (not doubled)
- [ ] Manual: verify Insights chart values and longest streak are accurate

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)