### PR TITLE
Deduplicate CityColor entries after CloudKit sync

### DIFF
--- a/Roam/ContentView.swift
+++ b/Roam/ContentView.swift
@@ -81,6 +81,7 @@ struct ContentView: View {
                 await attemptForegroundCapture()
                 BackfillService.backfillMissedNights(context: context)
                 DeduplicationService.deduplicateNightLogs(context: context)
+                DeduplicationService.deduplicateCityColors(context: context)
                 assignMissingColors()
             }
         }

--- a/Roam/Services/DeduplicationService.swift
+++ b/Roam/Services/DeduplicationService.swift
@@ -38,6 +38,29 @@ enum DeduplicationService {
         }
     }
 
+    /// Remove duplicate CityColor entries that share the same cityKey.
+    /// Keeps the entry with the lowest colorIndex (earliest assigned color).
+    @MainActor
+    static func deduplicateCityColors(context: ModelContext) {
+        let allColors = (try? context.fetch(FetchDescriptor<CityColor>())) ?? []
+
+        let grouped = Dictionary(grouping: allColors) { $0.cityKey }
+
+        var deletedCount = 0
+        for (_, colors) in grouped where colors.count > 1 {
+            let sorted = colors.sorted { $0.colorIndex < $1.colorIndex }
+            for color in sorted.dropFirst() {
+                context.delete(color)
+                deletedCount += 1
+            }
+        }
+
+        if deletedCount > 0 {
+            try? context.save()
+            logger.info("Deduplicated \(deletedCount) CityColor entries")
+        }
+    }
+
     private static func statusPriority(_ status: LogStatus) -> Int {
         switch status {
         case .confirmed: return 0

--- a/RoamTests/DeduplicationServiceTests.swift
+++ b/RoamTests/DeduplicationServiceTests.swift
@@ -118,6 +118,35 @@ final class DeduplicationServiceTests: XCTestCase {
         XCTAssertEqual(logs[1].capturedAt, d2newer.capturedAt)
     }
 
+    // MARK: - CityColor deduplication
+
+    func testDuplicateCityColors_keepsLowestColorIndex() {
+        let color1 = CityColor(cityKey: "Atlanta|GA|US", colorIndex: 0)
+        let color2 = CityColor(cityKey: "Atlanta|GA|US", colorIndex: 3)
+        context.insert(color1)
+        context.insert(color2)
+        try! context.save()
+
+        DeduplicationService.deduplicateCityColors(context: context)
+
+        let colors = try! context.fetch(FetchDescriptor<CityColor>())
+        XCTAssertEqual(colors.count, 1)
+        XCTAssertEqual(colors[0].colorIndex, 0)
+    }
+
+    func testNoDuplicateCityColors_noChanges() {
+        let color1 = CityColor(cityKey: "Atlanta|GA|US", colorIndex: 0)
+        let color2 = CityColor(cityKey: "Asheville|NC|US", colorIndex: 1)
+        context.insert(color1)
+        context.insert(color2)
+        try! context.save()
+
+        DeduplicationService.deduplicateCityColors(context: context)
+
+        let colors = try! context.fetch(FetchDescriptor<CityColor>())
+        XCTAssertEqual(colors.count, 2)
+    }
+
     // MARK: - Helpers
 
     private func noonUTC(_ year: Int, _ month: Int, _ day: Int) -> Date {


### PR DESCRIPTION
## Summary
- Add `deduplicateCityColors` to `DeduplicationService` — groups by `cityKey`, keeps lowest `colorIndex`
- Wire into `ContentView.task` after NightLog dedup, before color assignment
- 2 new unit tests (duplicate and no-duplicate cases)

## Test plan
- [x] 76 unit tests passing, 0 failures
- [ ] Manual: rebuild app, verify Timeline legend shows each city once

Follow-up to #17 / PR #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)