### PR TITLE
Fix YearSummaryBar overflowing horizontal margin

### DIFF
--- a/Roam/Views/Dashboard/YearSummaryBar.swift
+++ b/Roam/Views/Dashboard/YearSummaryBar.swift
@@ -18,10 +18,13 @@ struct YearSummaryBar: View {
             }
 
             GeometryReader { geo in
-                HStack(spacing: 2) {
+                let spacing: CGFloat = 2
+                let totalSpacing = spacing * CGFloat(max(cityDays.count - 1, 0))
+                let availableWidth = geo.size.width - totalSpacing
+                HStack(spacing: spacing) {
                     ForEach(Array(cityDays.enumerated()), id: \.offset) { _, entry in
                         let width = totalDays > 0
-                            ? geo.size.width * CGFloat(entry.days) / CGFloat(totalDays)
+                            ? availableWidth * CGFloat(entry.days) / CGFloat(totalDays)
                             : 0
                         RoundedRectangle(cornerRadius: RoamTheme.yearBarCornerRadius)
                             .fill(entry.color)


### PR DESCRIPTION
## Summary
- Subtract inter-segment HStack spacing from available width before distributing proportionally among bar segments
- Previously, the `2pt` spacing between segments was added on top of `geo.size.width`, causing the bar to overflow its container

## Test plan
- [ ] Manual QA: run on iPhone SE and iPhone 17 Pro Max simulator; confirm right edge aligns with sibling dashboard cards
- [ ] Edge case: verify long day-count labels (e.g., "365 days logged") don't push the bar further right

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)