### PR TITLE
feat: reveal build number via triple-tap on Version row

### DIFF
--- a/Roam/Views/Settings/SettingsView.swift
+++ b/Roam/Views/Settings/SettingsView.swift
@@ -21,6 +21,7 @@ struct SettingsView: View {
     @AppStorage("iCloudSyncEnabled") private var iCloudSyncEnabled: Bool = true
     @State private var showSyncRestartAlert = false
     @State private var aboutTapCount = 0
+    @State private var showBuildNumber = false
     @State private var systemNotificationsDenied = false
 
     private var settings: UserSettings {
@@ -174,7 +175,14 @@ struct SettingsView: View {
                 }
 
                 Section("About") {
-                    LabeledContent("Version", value: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—")
+                    LabeledContent("Version") {
+                        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—"
+                        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?"
+                        Text(showBuildNumber ? "\(version) (\(build))" : version)
+                    }
+                    .onTapGesture(count: 3) {
+                        showBuildNumber.toggle()
+                    }
                     Text("Roam passively monitors your location to automatically track which cities you visit. Location data is stored on-device and synced via iCloud. Your data is never shared with third parties.")
                         .font(.caption)
                         .foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary
- Triple-tapping the Version row in Settings toggles display from `1.0.0` to `1.0.0 (42)`
- Reads `CFBundleVersion` from bundle at runtime — matches existing triple-tap debug pattern

## Test plan
- [x] 79 tests pass (no new tests — pure UI change)
- [ ] Manual: Settings → About → triple-tap Version → verify build number appears

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)